### PR TITLE
Refatoração do footer

### DIFF
--- a/app/assets/stylesheets/home_template/css/style.scss
+++ b/app/assets/stylesheets/home_template/css/style.scss
@@ -1,5 +1,6 @@
 
 $bgcolor-home: #7971ea;
+$bgcolor-black: #040F0F;
 
 /* Base */
 body {
@@ -20,6 +21,9 @@ body {
 /* Navbar home */
 
 .navbar-dark {
+
+  background-color: $bgcolor-black;
+  box-shadow: 0px 0px 20px $bgcolor-home;
 
   .user {
     width: 50px;
@@ -44,9 +48,6 @@ body {
     }
   }
 
-  background-color: #040F0F;
-  box-shadow: 0px 0px 20px $bgcolor-home;
-
   .dropdown-toggle::after {
     content: none !important;
   }
@@ -61,13 +62,13 @@ body {
     }
 
     .dropdown-menu{
-      background-color: #040F0F;
+      background-color: $bgcolor-black;
       box-shadow: 0px 0px 5px $bgcolor-home;
       overflow: hidden;
       .dropdown-item {
         margin: 0;
         &:hover {
-          background-color: #040F0F;
+          background-color: $bgcolor-black;
         }
       }
     }
@@ -79,6 +80,15 @@ body {
     text-align: left;
   }
 }
+
+/* Footer */
+
+.footer-section {
+  background-color: $bgcolor-black;
+  padding-top: 2em;
+  color: #FFFFFF;
+}
+
 
 h1, h2, h3, h4, h5,
 .h1, .h2, .h3, .h4, .h5 {
@@ -161,29 +171,6 @@ h1, h2, h3, h4, h5,
 .border-top {
   border-top: 1px solid #edf0f5 !important; }
 
-.site-footer {
-  padding: 4em 0;
-  background: #333333; }
-  @media (min-width: 768px) {
-    .site-footer {
-      padding: 8em 0; } }
-  .site-footer .border-top {
-    border-top: 1px solid rgba(255, 255, 255, 0.1) !important; }
-  .site-footer p {
-    color: #737373; }
-  .site-footer h2, .site-footer h3, .site-footer h4, .site-footer h5 {
-    color: #000; }
-  .site-footer a {
-    color: #999999; }
-    .site-footer a:hover {
-      color: black; }
-  .site-footer ul li {
-    margin-bottom: 10px; }
-  .site-footer .footer-heading {
-    font-size: 16px;
-    color: #000;
-    text-transform: uppercase;
-    font-weight: 900; }
 
 .bg-text-line {
   display: inline;
@@ -570,25 +557,6 @@ h1, h2, h3, h4, h5,
       background-color: #e6e6e6; }
     .nonloop-block-14 .owl-dots .owl-dot.active span {
       background-color: #7971ea; }
-
-.footer-section {
-  padding: 7em 0;
-  background-color: #fafafa; }
-  .footer-section p {
-    font-size: 1rem; }
-  .footer-section h3 {
-    font-size: .9rem;
-    letter-spacing: .1rem;
-    text-transform: uppercase;
-    color: #000;
-    margin-bottom: 1.5rem;
-    font-weight: 900; }
-  .footer-section .footer-links li {
-    margin-bottom: 10px; }
-
-.footer-subscribe .btn {
-  height: 43px;
-  line-height: 1; }
 
 .testimony h3 {
   color: #fff;

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,3 +1,5 @@
+<% @title = Course.model_name.human(count: :other)  %>
+
 <h5 aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="<%= root_path %>"

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,45 +1,28 @@
-<footer class="footer-section bg-white">
+<footer class="footer-section">
   <div class="container" id="footer-section">
     <div class="row">
       <div class="col-md-4">
-        <h3>Sobre à CodePlay</h3>
-        <p>Nossa missão é propiciar educação online de qualidade</p>
+        <h3>Sobre a CodePlay</h3>
+        <p>Nossa missão é propiciar educação online de qualidade!</p>
       </div>
 
       <div class="col-md-3 ml-auto">
-        <h3>Links</h3>
-        <ul class="list-unstyled footer-links">
-          <li>
-            <%= link_to t('buttons.home'), root_path %>
-          </li>
-          <li>
-            <%= link_to t('buttons.courses'), courses_path %>
-          </li>
-          <li>
-            <%= link_to t('buttons.subscriptions'), subscriptions_path %>
-          </li>
-        </ul>
+        <%= link_to root_path do%>
+          <%= image_tag 'logo-codeplay-branco.png', alt:'home', class: 'img-fluid' %>
+        <% end %>
       </div>
 
       <div class="col-md-4">
-        <h3>Deixe seu email</h3>
-        <p>Para receber avisos e notícias por email</p>
-        <form action="#" class="footer-subscribe">
-          <div class="d-flex mb-5">
-            <input type="text" class="form-control rounded-0" placeholder="Email">
-            <input type="submit" class="btn btn-primary rounded-0" value="Subscribe">
-          </div>
-        </form>
       </div>
 
     </div>
 
-    <div class="row pt-5 mt-5 text-center">
+    <div class="row pt-5 text-center">
       <div class="col-md-12">
         <div class="border-top pt-5">
         <p>
           <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-          Copyright &copy;CodePlay <%= Time.now.year %> 
+          Copyright &copy;CodePlay <%= Time.now.year %>
           <!--<i class="icon-heart" aria-hidden="true"></i> by <a href="https://colorlib.com" target="_blank" >Colorlib</a>-->
           <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
         </p>
@@ -47,4 +30,4 @@
       </div>
     </div>
   </div>
-</footer>      
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,9 @@
 <nav class="navbar navbar-dark navbar-expand-lg">
   <div class="container-fluid">
     <div class="site-logo mr-auto">
-      <%= image_tag 'logo-codeplay-branco.png', alt:'Logo da code play', class: 'img-fluid' %>
+      <%= link_to root_path do %>
+        <%= image_tag 'logo-codeplay-branco.png', alt:'Logo da code play', class: 'img-fluid' %>
+      <% end %>
     </div>
 
     <button class="navbar-toggler" type="button"

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -1,3 +1,5 @@
+<% @title = Subscription.model_name.human(count: :other)  %>
+
 <h5 aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="<%= root_path %>"

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -234,7 +234,6 @@ describe 'Home page' do
         sleep 0.5
 
         within '.footer-section' do
-          expect(page).to have_content('SOBRE A CODEPLAY')
           expect(page).to have_content('Nossa missão é propiciar educação online de qualidade!')
           find("img[alt='home']").click
           expect(current_path).to eq(root_path)

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -24,6 +24,13 @@ describe 'Home page' do
         click_on 'Nova Conta'
         expect(current_path).to eq(new_user_registration_path)
       end
+
+      it 'can click on logo' do
+        visit courses_path
+
+        find("img[alt='Logo da code play']").click
+        expect(current_path).to eq(root_path)
+      end
     end
 
     context 'intro content' do
@@ -227,13 +234,10 @@ describe 'Home page' do
         sleep 0.5
 
         within '.footer-section' do
-          expect(page).to have_content('SOBRE À CODEPLAY')
-          expect(page).to have_content('Nossa missão é propiciar educação online de qualidade')
-          expect(page).to have_content('DEIXE SEU EMAIL')
-          expect(page).to have_content('Para receber avisos e notícias por email')
-          expect(page).to have_link('Home', href: root_path)
-          expect(page).to have_link('Cursos', href: courses_path)
-          expect(page).to have_link('Assinaturas', href: subscriptions_path)
+          expect(page).to have_content('SOBRE A CODEPLAY')
+          expect(page).to have_content('Nossa missão é propiciar educação online de qualidade!')
+          find("img[alt='home']").click
+          expect(current_path).to eq(root_path)
         end
       end
     end

--- a/spec/system/user/buy_subscription_spec.rb
+++ b/spec/system/user/buy_subscription_spec.rb
@@ -14,7 +14,7 @@ describe 'Authenticated user buy subscription' do
   context 'when status is approved' do
     it 'returns successfully with credit card' do
       returned_token = Faker::Alphanumeric.alphanumeric(number: 10)
-      allow(Invoice).to receive(:get_request).and_return([{ status: 'approved', token: returned_token }])
+      allow(Invoice).to receive(:generate).and_return({ status: 'approved', token: returned_token })
 
       login_user
       subscription = Fabricate(:subscription)
@@ -34,7 +34,7 @@ describe 'Authenticated user buy subscription' do
 
     it 'returns successfully with pix' do
       returned_token = Faker::Alphanumeric.alphanumeric(number: 10)
-      allow(Invoice).to receive(:get_request).and_return([{ status: 'approved', token: returned_token }])
+      allow(Invoice).to receive(:generate).and_return({ status: 'approved', token: returned_token })
       login_user
       subscription = Fabricate(:subscription)
 
@@ -52,7 +52,7 @@ describe 'Authenticated user buy subscription' do
 
     it 'returns successfully with boleto' do
       returned_token = Faker::Alphanumeric.alphanumeric(number: 10)
-      allow(Invoice).to receive(:get_request).and_return([{ status: 'approved', token: returned_token }])
+      allow(Invoice).to receive(:generate).and_return({ status: 'approved', token: returned_token })
       login_user
       subscription = Fabricate(:subscription)
 

--- a/spec/system/user/courses_spec.rb
+++ b/spec/system/user/courses_spec.rb
@@ -47,4 +47,15 @@ describe 'Course Management' do
 
     expect(current_path).to eq(new_user_session_path)
   end
+
+  it 'can see footer in courses page' do
+    visit courses_path
+
+    within '.footer-section' do
+      expect(page).to have_content('SOBRE A CODEPLAY')
+      expect(page).to have_content('Nossa missão é propiciar educação online de qualidade!')
+      find("img[alt='home']").click
+      expect(current_path).to eq(root_path)
+    end
+  end
 end

--- a/spec/system/user/courses_spec.rb
+++ b/spec/system/user/courses_spec.rb
@@ -52,7 +52,6 @@ describe 'Course Management' do
     visit courses_path
 
     within '.footer-section' do
-      expect(page).to have_content('SOBRE A CODEPLAY')
       expect(page).to have_content('Nossa missão é propiciar educação online de qualidade!')
       find("img[alt='home']").click
       expect(current_path).to eq(root_path)

--- a/spec/system/user/subscription_spec.rb
+++ b/spec/system/user/subscription_spec.rb
@@ -17,4 +17,15 @@ describe 'View Subscriptions' do
     expect(page).to have_text(other_subscription.name)
     expect(page).to have_text(other_subscription.description)
   end
+
+  it 'can see footer in subscriptions page' do
+    visit subscriptions_path
+
+    within '.footer-section' do
+      expect(page).to have_content('SOBRE A CODEPLAY')
+      expect(page).to have_content('Nossa missão é propiciar educação online de qualidade!')
+      find("img[alt='home']").click
+      expect(current_path).to eq(root_path)
+    end
+  end
 end

--- a/spec/system/user/subscription_spec.rb
+++ b/spec/system/user/subscription_spec.rb
@@ -22,7 +22,6 @@ describe 'View Subscriptions' do
     visit subscriptions_path
 
     within '.footer-section' do
-      expect(page).to have_content('SOBRE A CODEPLAY')
       expect(page).to have_content('Nossa missão é propiciar educação online de qualidade!')
       find("img[alt='home']").click
       expect(current_path).to eq(root_path)


### PR DESCRIPTION
## Motivação
Footer tinha informações desnecessárias como campo de email que não funcionava e links para outras páginas que a navbar fixed já possibilita acesso e seu tamanho estava desproporcional ao número de informações.

## Solução Proposta
Remoção de links no footer, redução de sua altura e mudança de cor para dar detaque. Inserção da logo da codeplay que funciona como link para home.
## Imagens
![image](https://user-images.githubusercontent.com/41846128/116832299-e625b700-ab8a-11eb-9537-b2a8dd7d372c.png)


## Comentários

## Issue
